### PR TITLE
Make StreamingParser.keepAliveUntil accessable outside the SwiftServerHttp module

### DIFF
--- a/Sources/SwiftServerHttp/StreamingParser.swift
+++ b/Sources/SwiftServerHttp/StreamingParser.swift
@@ -27,7 +27,7 @@ public class StreamingParser: HTTPResponseWriter {
     /// Tracks when socket should be closed. Needs to have a lock, since it's updated often
     private let _keepAliveUntilLock = DispatchSemaphore(value: 1)
     private var _keepAliveUntil: TimeInterval?
-    var keepAliveUntil: TimeInterval? {
+    public var keepAliveUntil: TimeInterval? {
         get {
             _keepAliveUntilLock.wait()
             defer {


### PR DESCRIPTION
`StreamingParser.keepAliveUntil` is an `internal` variable and thus only accessible within the SwiftServerHttp module.

One can't create classes outside of SwiftServerHttp in the style of BlueSocketConnectionListener as a result.

This PR makes `StreamingParser.keepAliveUntil` `public`