### PR TITLE
Convert HTTPVersion to a struct

### DIFF
--- a/API.md
+++ b/API.md
@@ -64,7 +64,14 @@ public struct HTTPHeaders {
 }
 
 /// Version number of the HTTP Protocol
-public typealias HTTPVersion = (Int, Int)
+public struct HTTPVersion {
+    /// Major version component.
+    public var major: Int
+    /// Minor version component.
+    public var minor: Int
+    
+    public init(major: Int, minor: Int)
+}
 
 public enum HTTPTransferEncoding {
     case identity(contentLength: UInt)

--- a/Sources/SwiftServerHttp/HTTPCommon.swift
+++ b/Sources/SwiftServerHttp/HTTPCommon.swift
@@ -9,7 +9,18 @@
 import Foundation
 
 /// Version number of the HTTP Protocol
-public typealias HTTPVersion = (Int, Int)
+public struct HTTPVersion {
+    /// Major version component.
+    public var major: Int
+    /// Minor version component.
+    public var minor: Int
+    
+    /// Creates an HTTP version.
+    public init(major: Int, minor: Int) {
+        self.major = major
+        self.minor = minor
+    }
+}
 
 /// Takes in a Request and an object to write to, and returns a function that handles reading the request body
 public typealias WebApp = (HTTPRequest, HTTPResponseWriter) -> HTTPBodyProcessing

--- a/Sources/SwiftServerHttp/HTTPCommon.swift
+++ b/Sources/SwiftServerHttp/HTTPCommon.swift
@@ -8,20 +8,6 @@
 
 import Foundation
 
-/// Version number of the HTTP Protocol
-public struct HTTPVersion {
-    /// Major version component.
-    public var major: Int
-    /// Minor version component.
-    public var minor: Int
-    
-    /// Creates an HTTP version.
-    public init(major: Int, minor: Int) {
-        self.major = major
-        self.minor = minor
-    }
-}
-
 /// Takes in a Request and an object to write to, and returns a function that handles reading the request body
 public typealias WebApp = (HTTPRequest, HTTPResponseWriter) -> HTTPBodyProcessing
 

--- a/Sources/SwiftServerHttp/HTTPVersion.swift
+++ b/Sources/SwiftServerHttp/HTTPVersion.swift
@@ -1,0 +1,43 @@
+// This source file is part of the Swift.org Server APIs open source project
+//
+// Copyright (c) 2017 Swift Server API project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+//
+
+/// Version number of the HTTP Protocol
+public struct HTTPVersion {
+    /// Major version component.
+    public private(set) var major: Int
+    /// Minor version component.
+    public private(set) var minor: Int
+    
+    /// Creates an HTTP version.
+    public init(major: Int, minor: Int) {
+        self.major = major
+        self.minor = minor
+    }
+}
+
+extension HTTPVersion : Hashable {
+    
+    public var hashValue: Int {
+        return major ^ minor
+    }
+    
+    public static func == (lhs: HTTPVersion, rhs: HTTPVersion) -> Bool {
+        return lhs.hashValue == rhs.hashValue
+    }
+    
+    public static func ~= (match: HTTPVersion, version: HTTPVersion) -> Bool {
+        return match == version
+    }
+}
+
+extension HTTPVersion : CustomStringConvertible {
+    public var description: String {
+        return "HTTP/" + major.description + "." + minor.description
+    }
+}
+

--- a/Sources/SwiftServerHttp/StreamingParser.swift
+++ b/Sources/SwiftServerHttp/StreamingParser.swift
@@ -190,7 +190,7 @@ public class StreamingParser: HTTPResponseWriter {
             if let methodName = http_method_str(http_method(rawValue: methodId)) {
                 self.parsedHTTPMethod = HTTPMethod(rawValue: String(validatingUTF8: methodName) ?? "GET")
             }
-            self.parsedHTTPVersion = (Int(self.httpParser.http_major), Int(self.httpParser.http_minor))
+            self.parsedHTTPVersion = HTTPVersion(major: Int(self.httpParser.http_major), minor: Int(self.httpParser.http_minor))
             
             self.parserBuffer=nil
             

--- a/Tests/SwiftServerHttpTests/SwiftServerHttpTests.swift
+++ b/Tests/SwiftServerHttpTests/SwiftServerHttpTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class SwiftServerHttpTests: XCTestCase {
     func testResponseOK() {
-        let request = HTTPRequest(method: .GET, target:"/echo", httpVersion: (1, 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .GET, target:"/echo", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: Data())
         resolver.resolveHandler(EchoWebApp().serve)
         XCTAssertNotNil(resolver.response)
@@ -22,7 +22,7 @@ class SwiftServerHttpTests: XCTestCase {
 
     func testEcho() {
         let testString="This is a test"
-        let request = HTTPRequest(method: .POST, target:"/echo", httpVersion: (1, 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .POST, target:"/echo", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: testString.data(using: .utf8)!)
         resolver.resolveHandler(EchoWebApp().serve)
         XCTAssertNotNil(resolver.response)
@@ -32,7 +32,7 @@ class SwiftServerHttpTests: XCTestCase {
     }
     
     func testHello() {
-        let request = HTTPRequest(method: .GET, target:"/helloworld", httpVersion: (1, 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .GET, target:"/helloworld", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: Data())
         resolver.resolveHandler(HelloWorldWebApp().serve)
         XCTAssertNotNil(resolver.response)
@@ -89,7 +89,7 @@ class SwiftServerHttpTests: XCTestCase {
     }
     
     func testSimpleHello() {
-        let request = HTTPRequest(method: .GET, target:"/helloworld", httpVersion: (1, 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .GET, target:"/helloworld", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: Data())
         let simpleHelloWebApp = SimpleResponseCreator { (request, body) -> (reponse: HTTPResponse, responseBody: Data) in
             return (HTTPResponse(httpVersion: request.httpVersion,


### PR DESCRIPTION
As per the proposal from @paulofaria, convert HTTPVersion from `(Int, Int)` to a struct. 

This allows the addition of Hashable, Equatable and CustomStringConvertible protocols - which haven't yet been added but can be if we're happy to move to a struct.

