### PR TITLE
move response write convenience methods to extension

### DIFF
--- a/Sources/SwiftServerHttp/HTTPResponse.swift
+++ b/Sources/SwiftServerHttp/HTTPResponse.swift
@@ -30,20 +30,42 @@ public struct HTTPResponse {
 /// Object that code writes the response and response body to. 
 public protocol HTTPResponseWriter : class {
     func writeContinue(headers: HTTPHeaders?) /* to send an HTTP `100 Continue` */
-    
     func writeResponse(_ response: HTTPResponse)
-    
     func writeTrailer(key: String, value: String)
-    
     func writeBody(data: DispatchData, completion: @escaping (Result<POSIXError, ()>) -> Void)
-    func writeBody(data: DispatchData) /* convenience */
-
     func writeBody(data: Data, completion: @escaping (Result<POSIXError, ()>) -> Void)
-    func writeBody(data: Data) /* convenience */
-
-    func done() /* convenience */
     func done(completion: @escaping (Result<POSIXError, ()>) -> Void)
     func abort()
+}
+
+/// Convenience methods for HTTP response writer.
+extension HTTPResponseWriter {
+    /// A convenience method for writing the supplied
+    /// `DispatchData` to the body of the HTTP response without
+    /// needing to supply a completion closure.
+    ///
+    /// - see: writeBody(data:completion:)
+    public func writeBody(data: DispatchData) {
+        return writeBody(data: data) { _ in }
+    }
+
+    /// A convenience method for writing the supplied
+    /// `Data` to the body of the HTTP response without
+    /// needing to supply a completion closure.
+    ///
+    /// - see: writeBody(data:completion:)
+    public func writeBody(data: Data) {
+        return writeBody(data: data) { _ in }
+    }
+
+    /// A convenience method for signalling that the
+    /// HTTP response is complete without needing to supply
+    /// a completion closure.
+    ///
+    /// - see: done(completion:)
+    public func done() {
+        done { _ in }
+    }
 }
 
 public enum HTTPTransferEncoding {

--- a/Sources/SwiftServerHttp/StreamingParser.swift
+++ b/Sources/SwiftServerHttp/StreamingParser.swift
@@ -376,13 +376,6 @@ public class StreamingParser: HTTPResponseWriter {
         writeBody(data: Data(data), completion: completion)
     }
     
-    
-    public func writeBody(data: DispatchData) /* convenience */ {
-        writeBody(data: data) { _ in
-            
-        }
-    }
-    
     public func writeBody(data: Data, completion: @escaping (Result<POSIXError, ()>) -> Void) {
         guard headersWritten else {
             //TODO error or default headers?
@@ -409,12 +402,6 @@ public class StreamingParser: HTTPResponseWriter {
         self.parserConnector?.queueSocketWrite(dataToWrite)
         
         completion(Result(completion: ()))
-    }
-    
-    public func writeBody(data: Data) /* convenience */ {
-        writeBody(data: data) { _ in
-            
-        }
     }
     
     public func done(completion: @escaping (Result<POSIXError, ()>) -> Void) {
@@ -446,12 +433,7 @@ public class StreamingParser: HTTPResponseWriter {
         
         completion(Result(completion: closeAfter()))
     }
-    
-    public func done() /* convenience */ {
-        done() { _ in
-        }
-    }
-    
+
     public func abort() {
         fatalError("abort called, not sure what to do with it")
     }


### PR DESCRIPTION
This PR moves what seem to be redundant HTTP response writer methods to a protocol extension instead. This should make it easier to conform to the `HTTPResponseWriter` protocol.
