### PR TITLE
rename webapp to responder

### DIFF
--- a/Sources/SwiftServerHttp/BlueSocketDriver/BlueSocketSimpleServer.swift
+++ b/Sources/SwiftServerHttp/BlueSocketDriver/BlueSocketSimpleServer.swift
@@ -65,7 +65,7 @@ public class BlueSocketSimpleServer : CurrentConnectionCounting {
     ///   - port: TCP port. See listen(2)
     ///   - webapp: Function that creates the HTTP Response from the HTTP Request
     /// - Throws: Error (usually a socket error) generated
-    public func start(port: Int = 0, queueCount: Int = 0, acceptCount: Int = 0, webapp: @escaping WebApp) throws {
+    public func start(port: Int = 0, queueCount: Int = 0, acceptCount: Int = 0, responder: @escaping Responder) throws {
         if queueCount > 0 {
             queueMax = queueCount
         }
@@ -98,7 +98,7 @@ public class BlueSocketSimpleServer : CurrentConnectionCounting {
             repeat {
                 do {
                     let clientSocket = try self.serverSocket.acceptClientConnection()
-                    let streamingParser = StreamingParser(webapp: webapp, connectionCounter: self)
+                    let streamingParser = StreamingParser(responder: responder, connectionCounter: self)
                     let readQueue = readQueues[listenerCount % self.queueMax]
                     let writeQueue = writeQueues[listenerCount % self.queueMax]
                     let listener = BlueSocketConnectionListener(socket:clientSocket, parser: streamingParser, readQueue:readQueue, writeQueue: writeQueue)

--- a/Sources/SwiftServerHttp/HTTPCommon.swift
+++ b/Sources/SwiftServerHttp/HTTPCommon.swift
@@ -9,12 +9,12 @@
 import Foundation
 
 /// Takes in a Request and an object to write to, and returns a function that handles reading the request body
-public typealias WebApp = (HTTPRequest, HTTPResponseWriter) -> HTTPBodyProcessing
+public typealias Responder = (HTTPRequest, HTTPResponseWriter) -> HTTPBodyProcessing
 
 /// Class protocol containing the WebApp func. Using a class protocol to allow weak references for ARC
-public protocol WebAppContaining: class {
+public protocol ResponderContaining: class {
     /// WebApp method
-    func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing
+    func serve(_ request: HTTPRequest, _ writer: HTTPResponseWriter) -> HTTPBodyProcessing
 }
 
 /// Headers structure.

--- a/Sources/SwiftServerHttp/StreamingParser.swift
+++ b/Sources/SwiftServerHttp/StreamingParser.swift
@@ -15,7 +15,7 @@ import CHttpParser
 /// Class that wraps the CHTTPParser and calls the `WebApp` to get the response
 public class StreamingParser: HTTPResponseWriter {
 
-    let webapp : WebApp
+    let responder: Responder
     
     /// Time to leave socket open waiting for next request to start
     public static let keepAliveTimeout: TimeInterval = 5
@@ -79,8 +79,8 @@ public class StreamingParser: HTTPResponseWriter {
     /// Class that wraps the CHTTPParser and calls the `WebApp` to get the response
     ///
     /// - Parameter webapp: function that is used to create the response
-    public init(webapp: @escaping WebApp, connectionCounter: CurrentConnectionCounting? = nil) {
-        self.webapp = webapp
+    public init(responder: @escaping Responder, connectionCounter: CurrentConnectionCounting? = nil) {
+        self.responder = responder
         self.connectionCounter = connectionCounter
         
         //Set up all the callbacks for the CHTTPParser library
@@ -173,7 +173,7 @@ public class StreamingParser: HTTPResponseWriter {
         case .headerFieldReceived:
             if let parserBuffer = self.parserBuffer {
                 self.lastHeaderName = String(data: parserBuffer, encoding: .utf8)
-                self.parserBuffer=nil
+                self.parserBuffer = nil
             } else {
                 print("Missing parserBuffer after \(lastCallBack)")
             }
@@ -195,7 +195,7 @@ public class StreamingParser: HTTPResponseWriter {
             self.parserBuffer=nil
             
             if !upgradeRequested {
-                self.httpBodyProcessingCallback = self.webapp(self.createRequest(), self)
+                httpBodyProcessingCallback = responder(self.createRequest(), self)
             }
         case .urlReceived:
             if let parserBuffer = self.parserBuffer {

--- a/Tests/SwiftServerHttpTests/Helpers/EchoWebApp.swift
+++ b/Tests/SwiftServerHttpTests/Helpers/EchoWebApp.swift
@@ -11,8 +11,8 @@ import SwiftServerHttp
 
 
 /// Simple `WebApp` that just echoes back whatever input it gets
-class EchoWebApp: WebAppContaining {
-    func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
+class EchoWebApp: ResponderContaining {
+    func serve(_ req: HTTPRequest, _ res: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
                                        status: .ok,

--- a/Tests/SwiftServerHttpTests/Helpers/HelloWorldKeepAliveWebApp.swift
+++ b/Tests/SwiftServerHttpTests/Helpers/HelloWorldKeepAliveWebApp.swift
@@ -10,8 +10,8 @@ import Foundation
 import SwiftServerHttp
 
 /// `HelloWorldWebApp` that sets the keep alive header for XCTest purposes
-class HelloWorldKeepAliveWebApp: WebAppContaining {
-    func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
+class HelloWorldKeepAliveWebApp: ResponderContaining {
+    func serve(_ req: HTTPRequest, _ res: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
                                        status: .ok,

--- a/Tests/SwiftServerHttpTests/Helpers/HelloWorldWebApp.swift
+++ b/Tests/SwiftServerHttpTests/Helpers/HelloWorldWebApp.swift
@@ -10,8 +10,8 @@ import Foundation
 import SwiftServerHttp
 
 /// Simple `WebApp` that prints "Hello, World" as per K&R
-class HelloWorldWebApp: WebAppContaining {
-    func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
+class HelloWorldWebApp: ResponderContaining {
+    func serve(_ req: HTTPRequest, _ res: HTTPResponseWriter) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
                                        status: .ok,

--- a/Tests/SwiftServerHttpTests/Helpers/SimpleResponseCreator.swift
+++ b/Tests/SwiftServerHttpTests/Helpers/SimpleResponseCreator.swift
@@ -17,7 +17,7 @@ import Foundation
 import SwiftServerHttp
 
 /// Simple block-based wrapper to create a `WebApp`. Normally used during XCTests
-public class SimpleResponseCreator: WebAppContaining {
+public class SimpleResponseCreator: ResponderContaining {
     
     typealias SimpleHandlerBlock = (_ req: HTTPRequest, _ body: Data) -> (reponse: HTTPResponse, responseBody: Data)
     let completionHandler: SimpleHandlerBlock
@@ -28,7 +28,7 @@ public class SimpleResponseCreator: WebAppContaining {
     
     var buffer = Data()
     
-    public func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    public func serve(_ req: HTTPRequest, _ res: HTTPResponseWriter) -> HTTPBodyProcessing {
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(let data, let finishedProcessing):

--- a/Tests/SwiftServerHttpTests/Helpers/TestResponseResolver.swift
+++ b/Tests/SwiftServerHttpTests/Helpers/TestResponseResolver.swift
@@ -26,7 +26,7 @@ class TestResponseResolver: HTTPResponseWriter {
         }
     }
     
-    func resolveHandler(_ handler:WebApp) {
+    func resolveHandler(_ handler: Responder) {
         let chunkHandler = handler(request, self)
         var stop=false
         var finished=false

--- a/Tests/SwiftServerHttpTests/SwiftServerHttpTests.swift
+++ b/Tests/SwiftServerHttpTests/SwiftServerHttpTests.swift
@@ -111,7 +111,7 @@ class SwiftServerHttpTests: XCTestCase {
         
         let server = BlueSocketSimpleServer()
         do {
-            try server.start(port: 0, webapp: HelloWorldWebApp().serve)
+            try server.start(port: 0, responder: HelloWorldWebApp().serve)
             let session = URLSession(configuration: URLSessionConfiguration.default)
             let url = URL(string: "http://localhost:\(server.port)/helloworld")!
             print("Test \(#function) on port \(server.port)")
@@ -149,7 +149,7 @@ class SwiftServerHttpTests: XCTestCase {
 
         let server = BlueSocketSimpleServer()
         do {
-            try server.start(port: 0, webapp: simpleHelloWebApp.serve)
+            try server.start(port: 0, responder: simpleHelloWebApp.serve)
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -186,7 +186,7 @@ class SwiftServerHttpTests: XCTestCase {
 
         let server = BlueSocketSimpleServer()
         do {
-            try server.start(port: 0, webapp: EchoWebApp().serve)
+            try server.start(port: 0, responder: EchoWebApp().serve)
             let session = URLSession(configuration: URLSessionConfiguration.default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -226,7 +226,7 @@ class SwiftServerHttpTests: XCTestCase {
         
         let server = BlueSocketSimpleServer()
         do {
-            try server.start(port: 0, webapp: EchoWebApp().serve)
+            try server.start(port: 0, responder: EchoWebApp().serve)
             let session = URLSession(configuration: URLSessionConfiguration.default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -324,7 +324,7 @@ class SwiftServerHttpTests: XCTestCase {
         
         let server = BlueSocketSimpleServer()
         do {
-            try server.start(port: 0, webapp: EchoWebApp().serve)
+            try server.start(port: 0, responder: EchoWebApp().serve)
             let session = URLSession(configuration: URLSessionConfiguration.default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")


### PR DESCRIPTION
Changed the `ResponderContaining` protocol to not specify argument labels. The current arguments labels of `req` and `res` are awkward looking in Swift which usually favors readable method names over abbreviated words. Additionally `res` is not entirely accurate since it's actually a response _writer_. 

Not requiring method labels here could be a good compromise here since the two arguments are strongly typed anyway.

This is a rather trivial change, but I think `Responder` sounds nicer than `WebApp`. 