### PR TITLE
Change HTTPRequest.target type form String to URL

### DIFF
--- a/Sources/HTTP/HTTPRequest.swift
+++ b/Sources/HTTP/HTTPRequest.swift
@@ -12,7 +12,7 @@ import Dispatch
 /// HTTP Request NOT INCLUDING THE BODY. This allows for streaming
 public struct HTTPRequest {
     public var method: HTTPMethod
-    public var target: String /* e.g. "/foo/bar?buz=qux" */
+    public var target: URL
     public var httpVersion: HTTPVersion
     public var headers: HTTPHeaders
 }

--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -71,7 +71,7 @@ public class StreamingParser: HTTPResponseWriter {
     var parsedHeaders = HTTPHeaders()
     var parsedHTTPMethod: HTTPMethod?
     var parsedHTTPVersion: HTTPVersion?
-    var parsedURL: String?
+    var parsedURL: URL?
 
     /// Is the currently parsed request an upgrade request?
     public private(set) var upgradeRequested = false
@@ -201,7 +201,9 @@ public class StreamingParser: HTTPResponseWriter {
             if let parserBuffer = self.parserBuffer {
                 //Under heaptrack, this may appear to leak via _CFGetTSDCreateIfNeeded, 
                 //  apparently, that's because it triggers thread metadata to be created
-                self.parsedURL = String(data:parserBuffer, encoding: .utf8)
+                if let parsedString = String(data: parserBuffer, encoding: .utf8) {
+                    self.parsedURL = URL(string: parsedString)
+                }
                 self.parserBuffer=nil
             } else {
                 print("Missing parserBuffer after \(lastCallBack)")

--- a/Tests/BlueSocketHTTPTests/ServerTests.swift
+++ b/Tests/BlueSocketHTTPTests/ServerTests.swift
@@ -11,9 +11,14 @@ import XCTest
 @testable import HTTP
 @testable import BlueSocketHTTP
 
+struct Targets {
+    static let echo = URL(string: "/echo")!
+    static let helloworld = URL(string: "/helloworld")!
+}
+
 class ServerTests: XCTestCase {
     func testResponseOK() {
-        let request = HTTPRequest(method: .GET, target:"/echo", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .GET, target: Targets.echo, httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: Data())
         resolver.resolveHandler(EchoWebApp().serve)
         XCTAssertNotNil(resolver.response)
@@ -23,7 +28,7 @@ class ServerTests: XCTestCase {
 
     func testEcho() {
         let testString="This is a test"
-        let request = HTTPRequest(method: .POST, target:"/echo", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .POST, target: Targets.echo, httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: testString.data(using: .utf8)!)
         resolver.resolveHandler(EchoWebApp().serve)
         XCTAssertNotNil(resolver.response)
@@ -33,7 +38,7 @@ class ServerTests: XCTestCase {
     }
     
     func testHello() {
-        let request = HTTPRequest(method: .GET, target:"/helloworld", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .GET, target: Targets.helloworld, httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: Data())
         resolver.resolveHandler(HelloWorldWebApp().serve)
         XCTAssertNotNil(resolver.response)
@@ -43,7 +48,7 @@ class ServerTests: XCTestCase {
     }
     
     func testSimpleHello() {
-        let request = HTTPRequest(method: .GET, target:"/helloworld", httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
+        let request = HTTPRequest(method: .GET, target: Targets.helloworld, httpVersion: HTTPVersion(major: 1, minor: 1), headers: HTTPHeaders([("X-foo", "bar")]))
         let resolver = TestResponseResolver(request: request, requestBody: Data())
         let simpleHelloWebApp = SimpleResponseCreator { (request, body) -> (reponse: HTTPResponse, responseBody: Data) in
             return (HTTPResponse(httpVersion: request.httpVersion,


### PR DESCRIPTION
This PR changes the [`HTTPRequest.target`](https://github.com/swift-server/http/blob/develop/Sources/HTTP/HTTPRequest.swift#L15) property's type from `String` to `URL`. This accomplishes a few things:

  * Clarifies the type of data stored in the property.
  * Ensures the value is a valid URL.
  * Provides easy access to individual URL components.