### PR TITLE
Grab the lock when calculating the count property

### DIFF
--- a/Sources/BlueSocketHTTP/BlueSocketSimpleServer.swift
+++ b/Sources/BlueSocketHTTP/BlueSocketSimpleServer.swift
@@ -163,7 +163,9 @@ class ConnectionListenerCollection {
     
     /// Used when shutting down the server to close all connections
     func closeAll() {
+        lock.wait()
         storage.filter { nil != $0.value }.forEach { $0.value?.close() }
+        lock.signal()
     }
     
     /// Close any idle sockets and remove any weak pointers to closed (and freed) sockets from the collection
@@ -176,6 +178,9 @@ class ConnectionListenerCollection {
     
     /// Count of collections
     var count: Int {
-        return storage.filter { nil != $0.value }.count
+        lock.wait()
+        let c = storage.filter { nil != $0.value }.count
+        lock.signal()
+        return c
     }
 }


### PR DESCRIPTION
Calculating the number of active connection listeners requires iterating through the underlying storage array, hence we need to take the lock the lock since new listeners may be appended to it concurrently. This fixes crashes that are seen under non-trivial load.