### PR TITLE
.discardBody should call done()

### DIFF
--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -233,7 +233,7 @@ public class StreamingParser: HTTPResponseWriter {
             case .processBody(let handler):
                 handler(.end, &stop)
             case .discardBody:
-                break
+                done()
             }
         }
         return 0

--- a/Tests/BlueSocketHTTPTests/Helpers/OkWebApp.swift
+++ b/Tests/BlueSocketHTTPTests/Helpers/OkWebApp.swift
@@ -1,0 +1,22 @@
+// This source file is part of the Swift.org Server APIs open source project
+//
+// Copyright (c) 2017 Swift Server API project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+//
+
+import Foundation
+import HTTP
+
+/// Simple `WebApp` that returns 200: OK without a body
+class OkWebApp: WebAppContaining {
+    func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
+        //Assume the router gave us the right request - at least for now
+        res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
+                                       status: .ok,
+                                       transferEncoding: .chunked,
+                                       headers: ["X-foo": "bar"]))
+        return .discardBody
+    }
+}

--- a/Tests/BlueSocketHTTPTests/ServerTests.swift
+++ b/Tests/BlueSocketHTTPTests/ServerTests.swift
@@ -59,6 +59,35 @@ class ServerTests: XCTestCase {
         XCTAssertEqual(HTTPResponseStatus.ok.code, resolver.response?.status.code ?? 0)
         XCTAssertEqual("Hello, World!", String(data: resolver.responseBody ?? Data(), encoding: .utf8) ?? "Nil")
     }
+    
+    func testOkEndToEnd() {
+        let receivedExpectation = self.expectation(description: "Received web response \(#function)")
+        
+        let server = BlueSocketSimpleServer()
+        do {
+            try server.start(port: 0, webapp: OkWebApp().serve)
+            let session = URLSession(configuration: URLSessionConfiguration.default)
+            let url = URL(string: "http://localhost:\(server.port)/")!
+            print("Test \(#function) on port \(server.port)")
+            let dataTask = session.dataTask(with: url) { (responseBody, rawResponse, error) in
+                let response = rawResponse as? HTTPURLResponse
+                XCTAssertNil(error, "\(error!.localizedDescription)")
+                XCTAssertNotNil(response)
+                XCTAssertNotNil(responseBody)
+                XCTAssertEqual(Int(HTTPResponseStatus.ok.code), response?.statusCode ?? 0)
+                receivedExpectation.fulfill()
+            }
+            dataTask.resume()
+            self.waitForExpectations(timeout: 10) { (error) in
+                if let error = error {
+                    XCTFail("\(error)")
+                }
+            }
+            server.stop()
+        } catch {
+            XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
+        }
+    }
 
     func testHelloEndToEnd() {
         let receivedExpectation = self.expectation(description: "Received web response \(#function)")
@@ -311,6 +340,7 @@ class ServerTests: XCTestCase {
         ("testHello", testHello),
         ("testSimpleHello", testSimpleHello),
         ("testResponseOK", testResponseOK),
+        ("testOkEndToEnd", testOkEndToEnd),
         ("testHelloEndToEnd", testHelloEndToEnd),
         ("testSimpleHelloEndToEnd", testSimpleHelloEndToEnd),
         ("testRequestEchoEndToEnd", testRequestEchoEndToEnd),


### PR DESCRIPTION
Running the following code to return 200 OK currently results in a hang:
```swift
    func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
        //Assume the router gave us the right request - at least for now
        res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
                                       status: .ok,
                                       transferEncoding: .chunked,
                                       headers: ["X-foo": "bar"]))
        return .discardBody
```
This is because `.discardBody` doesn't result in an eventual cal to `done()` to return the response.

I've added a test for this, along with a simple fix.