### PR TITLE
Simplification of HTTPResponse/HTTPResponseWriter

### DIFF
--- a/Sources/HTTP/HTTPCommon.swift
+++ b/Sources/HTTP/HTTPCommon.swift
@@ -17,18 +17,7 @@ public protocol WebAppContaining: class {
     func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing
 }
 
-public enum Result<POSIXError, Void> {
-    case success(())
-    case failure(POSIXError)
-    
-    // MARK: Constructors
-    /// Constructs a success wrapping a `closure`.
-    public init(completion: ()) {
-        self = .success(completion)
-    }
-    
-    /// Constructs a failure wrapping an `POSIXError`.
-    public init(error: POSIXError) {
-        self = .failure(error)
-    }
+public enum Result {
+    case ok
+    case error(Error)
 }

--- a/Sources/HTTP/HTTPResponse.swift
+++ b/Sources/HTTP/HTTPResponse.swift
@@ -9,41 +9,27 @@
 import Foundation
 import Dispatch
 
-/// HTTP Response NOT INCLUDING THE BODY
-public struct HTTPResponse {
-    public var httpVersion: HTTPVersion
-    public var status: HTTPResponseStatus
-    public var transferEncoding: HTTPTransferEncoding
-    public var headers: HTTPHeaders
-    
-    public init (httpVersion: HTTPVersion, status: HTTPResponseStatus, transferEncoding: HTTPTransferEncoding, headers: HTTPHeaders) {
-        self.httpVersion = httpVersion
-        self.status = status
-        self.transferEncoding = transferEncoding
-        self.headers = headers
-    }
-}
-
 /// Object that code writes the response and response body to. 
 public protocol HTTPResponseWriter : class {
-    func writeContinue(headers: HTTPHeaders?) /* to send an HTTP `100 Continue` */
-    func writeResponse(_ response: HTTPResponse)
-    func writeTrailer(key: String, value: String)
-    func writeBody(data: DispatchData, completion: @escaping (Result<POSIXError, ()>) -> Void)
-    func writeBody(data: Data, completion: @escaping (Result<POSIXError, ()>) -> Void)
-    func done(completion: @escaping (Result<POSIXError, ()>) -> Void)
+    func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders, completion: @escaping (Result) -> Void)
+    func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void)
+    func writeBody(_ data: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void)
+    func done(completion: @escaping (Result) -> Void)
     func abort()
 }
 
 /// Convenience methods for HTTP response writer.
 extension HTTPResponseWriter {
-    /// A convenience method for writing the supplied
-    /// `DispatchData` to the body of the HTTP response without
-    /// needing to supply a completion closure.
-    ///
-    /// - see: writeBody(data:completion:)
-    public func writeBody(data: DispatchData) {
-        return writeBody(data: data) { _ in }
+    public func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders) {
+        writeHeader(status: status, headers: headers) { _ in }
+    }
+
+    public func writeHeader(status: HTTPResponseStatus) {
+        writeHeader(status: status, headers: [:])
+    }
+
+    public func writeTrailer(_ trailers: HTTPHeaders) {
+        writeTrailer(trailers) { _ in }
     }
 
     /// A convenience method for writing the supplied
@@ -51,8 +37,8 @@ extension HTTPResponseWriter {
     /// needing to supply a completion closure.
     ///
     /// - see: writeBody(data:completion:)
-    public func writeBody(data: Data) {
-        return writeBody(data: data) { _ in }
+    public func writeBody(_ data: UnsafeHTTPResponseBody) {
+        return writeBody(data) { _ in }
     }
 
     /// A convenience method for signalling that the
@@ -63,11 +49,6 @@ extension HTTPResponseWriter {
     public func done() {
         done { _ in }
     }
-}
-
-public enum HTTPTransferEncoding {
-    case identity(contentLength: UInt)
-    case chunked
 }
 
 /// Response status (200 ok, 404 not found, etc)
@@ -223,7 +204,57 @@ public struct HTTPResponseStatus: Equatable, CustomStringConvertible, Expressibl
         }
     }
 
+    // [RFC2616, section 4.4]
+    var bodyAllowed: Bool {
+        switch code {
+            case 100..<200: return false
+            case 204: return false
+            case 304: return false
+            default: return true
+        }
+    }
+
+    var suppressedHeaders: [HTTPHeaders.Name] {
+        if self == .notModified {
+            return ["Content-Type", "Content-Length", "Transfer-Encoding"]
+        } else if !bodyAllowed {
+            return ["Content-Length", "Transfer-Encoding"]
+        } else {
+            return []
+        }
+    }
+
     public static func ==(lhs: HTTPResponseStatus, rhs: HTTPResponseStatus) -> Bool {
         return lhs.code == rhs.code
+    }
+}
+
+public protocol UnsafeHTTPResponseBody {
+    func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R
+}
+
+extension UnsafeRawBufferPointer : UnsafeHTTPResponseBody {
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try body(self)
+    }
+}
+
+public protocol HTTPResponseBody : UnsafeHTTPResponseBody {}
+
+extension Data : HTTPResponseBody {
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try withUnsafeBytes { try body(UnsafeRawBufferPointer(start: $0, count: count)) }
+    }
+}
+
+extension DispatchData : HTTPResponseBody {
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try withUnsafeBytes { try body(UnsafeRawBufferPointer(start: $0, count: count)) }
+    }
+}
+
+extension String : HTTPResponseBody {
+    public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+        return try ContiguousArray(utf8).withUnsafeBytes(body)
     }
 }

--- a/Sources/HTTP/HTTPResponse.swift
+++ b/Sources/HTTP/HTTPResponse.swift
@@ -9,6 +9,13 @@
 import Foundation
 import Dispatch
 
+/// HTTP Response for possible use in the client.
+public struct HTTPResponse {
+    public var httpVersion : HTTPVersion
+    public var status: HTTPResponseStatus
+    public var headers: HTTPHeaders
+}
+
 /// Object that code writes the response and response body to. 
 public protocol HTTPResponseWriter : class {
     func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders, completion: @escaping (Result) -> Void)

--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -318,7 +318,7 @@ public class StreamingParser: HTTPResponseWriter {
             return
         }
         
-        var header = "\(parsedHTTPVersion!) \(status.code) \(status.reasonPhrase)\r\n"
+        var header = "HTTP/1.1 \(status.code) \(status.reasonPhrase)\r\n"
 
         let isContinue = status == .continue
 

--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -312,99 +312,109 @@ public class StreamingParser: HTTPResponseWriter {
         return HTTPRequest(method: parsedHTTPMethod!, target: parsedURL!, httpVersion: parsedHTTPVersion!, headers: parsedHeaders)
     }
     
-    public func writeContinue(headers: HTTPHeaders?) /* to send an HTTP `100 Continue` */ {
-        var status = "HTTP/1.1 \(HTTPResponseStatus.continue.code) \(HTTPResponseStatus.continue.reasonPhrase)\r\n"
-        if let headers = headers {
-            for (key, value) in headers.makeIterator() {
-                status += "\(key): \(value)\r\n"
-            }
-        }
-        status += "\r\n"
-        
-        // TODO use requested encoding if specified
-        if let data = status.data(using: .utf8) {
-            self.parserConnector?.queueSocketWrite(data)
-        } else {
-            //TODO handle encoding error
-        }
-    }
-    
-    public func writeResponse(_ response: HTTPResponse) {
+    public func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders, completion: @escaping (Result) -> Void) {
+        // TODO call completion()
         guard !headersWritten else {
             return
         }
         
-        var headers = "HTTP/1.1 \(response.status.code) \(response.status.reasonPhrase)\r\n"
-        
-        switch(response.transferEncoding) {
-        case .chunked:
-            headers += "Transfer-Encoding: chunked\r\n"
-            isChunked = true
-        case .identity(let contentLength):
-            headers += "Content-Length: \(contentLength)\r\n"
+        var header = "\(parsedHTTPVersion!) \(status.code) \(status.reasonPhrase)\r\n"
+
+        let isContinue = status == .continue
+
+        var headers = headers
+        if !isContinue {
+            adjustHeaders(status: status, headers: &headers)
         }
         
-        for (key, value) in response.headers.makeIterator() {
-            headers += "\(key): \(value)\r\n"
+        for (key, value) in headers {
+            // TODO encode value using [RFC5987]
+            header += "\(key): \(value)\r\n"
         }
+        header.append("\r\n")
         
-        let availableConnections = maxRequests - (self.connectionCounter?.connectionCount ?? 0)
-        
-        if  clientRequestedKeepAlive && (availableConnections > 0) {
-            headers.append("Connection: Keep-Alive\r\n")
-            headers.append("Keep-Alive: timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(availableConnections)\r\n")
-        }
-        else {
-            headers.append("Connection: Close\r\n")
-        }
-        headers.append("\r\n")
-        
+        // FIXME headers are US-ASCII, anything else should be encoded using [RFC5987] some lines above
         // TODO use requested encoding if specified
-        if let data = headers.data(using: .utf8) {
+        if let data = header.data(using: .utf8) {
             self.parserConnector?.queueSocketWrite(data)
-            headersWritten = true
+            if !isContinue {
+                headersWritten = true
+            }
         } else {
             //TODO handle encoding error
         }
     }
+
+    func adjustHeaders(status: HTTPResponseStatus, headers: inout HTTPHeaders) {
+        for header in status.suppressedHeaders {
+            headers[header] = nil
+        }
+
+        if headers[.contentLength] != nil {
+            headers[.transferEncoding] = "identity"
+        } else if parsedHTTPVersion! >= HTTPVersion(major: 1, minor: 1) {
+            switch headers[.transferEncoding] {
+                case .some("identity"): // identity without content-length
+                    clientRequestedKeepAlive = false
+                case .some("chunked"):
+                    isChunked = true
+                default:
+                    isChunked = true
+                    headers[.transferEncoding] = "chunked"
+            }
+        } else {
+            // HTTP 1.0 does not support chunked
+            clientRequestedKeepAlive = false
+            headers[.transferEncoding] = nil
+        }
+
+        let availableConnections = maxRequests - (self.connectionCounter?.connectionCount ?? 0)
+
+        if clientRequestedKeepAlive && (availableConnections > 0) {
+            headers[.connection] = "Keep-Alive"
+            headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(availableConnections)"
+        } else {
+            headers[.connection] = "Close"
+        }
+    }
     
-    public func writeTrailer(key: String, value: String) {
+    public func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void) {
         fatalError("Not implemented")
     }
     
-    public func writeBody(data: DispatchData, completion: @escaping (Result<POSIXError, ()>) -> Void) {
-        writeBody(data: Data(data), completion: completion)
-    }
-    
-    public func writeBody(data: Data, completion: @escaping (Result<POSIXError, ()>) -> Void) {
+    public func writeBody(_ data: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void) {
         guard headersWritten else {
             //TODO error or default headers?
             return
         }
         
-        guard data.count > 0 else {
-            // TODO fix Result
-            completion(Result(completion: ()))
+        guard data.withUnsafeBytes({ $0.count > 0 }) else {
+            completion(.ok)
             return
         }
         
-        var dataToWrite: Data!
+        let dataToWrite: Data
         if isChunked {
-            let chunkStart = (String(data.count, radix: 16) + "\r\n").data(using: .utf8)!
-            dataToWrite = Data(chunkStart)
-            dataToWrite.append(data)
-            let chunkEnd = "\r\n".data(using: .utf8)!
-            dataToWrite.append(chunkEnd)
+            dataToWrite = data.withUnsafeBytes {
+                let chunkStart = (String($0.count, radix: 16) + "\r\n").data(using: .utf8)!
+                var dataToWrite = chunkStart
+                dataToWrite.append(UnsafeBufferPointer(start: $0.baseAddress?.assumingMemoryBound(to: UInt8.self), count: $0.count))
+                let chunkEnd = "\r\n".data(using: .utf8)!
+                dataToWrite.append(chunkEnd)
+                return dataToWrite
+            }
+        } else if let d = data as? Data {
+            dataToWrite = d
         } else {
-            dataToWrite = data
+            dataToWrite = data.withUnsafeBytes { Data($0) }
         }
         
         self.parserConnector?.queueSocketWrite(dataToWrite)
         
-        completion(Result(completion: ()))
+        completion(.ok)
     }
     
-    public func done(completion: @escaping (Result<POSIXError, ()>) -> Void) {
+    public func done(completion: @escaping (Result) -> Void) {
         if isChunked {
             let chunkTerminate = "0\r\n\r\n".data(using: .utf8)!
             self.parserConnector?.queueSocketWrite(chunkTerminate)
@@ -431,7 +441,11 @@ public class StreamingParser: HTTPResponseWriter {
             }
         }
         
-        completion(Result(completion: closeAfter()))
+        // FIXME I do not understand what code written here before was meant to do
+        // If it was about delayed closure invocation then it couldn't work either
+        // Here is the equivalent code
+        closeAfter()
+        completion(.ok)
     }
 
     public func abort() {

--- a/Tests/BlueSocketHTTPTests/Helpers/EchoWebApp.swift
+++ b/Tests/BlueSocketHTTPTests/Helpers/EchoWebApp.swift
@@ -14,14 +14,11 @@ import HTTP
 class EchoWebApp: WebAppContaining {
     func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
-                                       status: .ok,
-                                       transferEncoding: .chunked,
-                                       headers: ["X-foo": "bar"]))
+        res.writeHeader(status: .ok, headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"])
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(let data, let finishedProcessing):
-                res.writeBody(data: data) { _ in
+                res.writeBody(data) { _ in
                     finishedProcessing()
                 }
             case .end:

--- a/Tests/BlueSocketHTTPTests/Helpers/HelloWorldKeepAliveWebApp.swift
+++ b/Tests/BlueSocketHTTPTests/Helpers/HelloWorldKeepAliveWebApp.swift
@@ -13,16 +13,17 @@ import HTTP
 class HelloWorldKeepAliveWebApp: WebAppContaining {
     func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
-                                       status: .ok,
-                                       transferEncoding: .chunked,
-                                       headers: ["Connection": "Keep-Alive", "Keep-Alive": "timeout=5, max=10"]))
+        res.writeHeader(status: .ok, headers: [
+            "Transfer-Encoding": "chunked",
+            "Connection": "Keep-Alive",
+            "Keep-Alive": "timeout=5, max=10",
+        ])
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(_, let finishedProcessing):
                 finishedProcessing()
             case .end:
-                res.writeBody(data: "Hello, World!".data(using: .utf8)!) { _ in }
+                res.writeBody("Hello, World!")
                 res.done()
             default:
                 stop = true /* don't call us anymore */

--- a/Tests/BlueSocketHTTPTests/Helpers/HelloWorldWebApp.swift
+++ b/Tests/BlueSocketHTTPTests/Helpers/HelloWorldWebApp.swift
@@ -13,16 +13,13 @@ import HTTP
 class HelloWorldWebApp: WebAppContaining {
     func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
-                                       status: .ok,
-                                       transferEncoding: .chunked,
-                                       headers: ["X-foo": "bar"]))
+        res.writeHeader(status: .ok, headers: [.transferEncoding: "chunked", "X-foo": "bar"])
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(_, let finishedProcessing):
                 finishedProcessing()
             case .end:
-                res.writeBody(data: "Hello, World!".data(using: .utf8)!) { _ in }
+                res.writeBody("Hello, World!")
                 res.done()
             default:
                 stop = true /* don't call us anymore */

--- a/Tests/BlueSocketHTTPTests/Helpers/OkWebApp.swift
+++ b/Tests/BlueSocketHTTPTests/Helpers/OkWebApp.swift
@@ -13,10 +13,7 @@ import HTTP
 class OkWebApp: WebAppContaining {
     func serve(req: HTTPRequest, res: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        res.writeResponse(HTTPResponse(httpVersion: req.httpVersion,
-                                       status: .ok,
-                                       transferEncoding: .chunked,
-                                       headers: ["X-foo": "bar"]))
+        res.writeHeader(status: .ok, headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"])
         return .discardBody
     }
 }

--- a/Tests/BlueSocketHTTPTests/Helpers/TestResponseResolver.swift
+++ b/Tests/BlueSocketHTTPTests/Helpers/TestResponseResolver.swift
@@ -15,8 +15,8 @@ class TestResponseResolver: HTTPResponseWriter {
     let request: HTTPRequest
     let requestBody: DispatchData
     
-    var response: HTTPResponse?
-    var responseBody: Data?
+    var response: (status: HTTPResponseStatus, headers: HTTPHeaders)?
+    var responseBody: HTTPResponseBody?
     
     
     init(request: HTTPRequest, requestBody: Data) {
@@ -43,41 +43,26 @@ class TestResponseResolver: HTTPResponseWriter {
         }
     }
     
-    func writeContinue(headers: HTTPHeaders?) /* to send an HTTP `100 Continue` */ {
+    func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders, completion: @escaping (Result) -> Void) {
+        self.response = (status: status, headers: headers)
+        completion(.ok)
+    }
+    
+    func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void) {
         fatalError("Not implemented")
     }
     
-    func writeResponse(_ response: HTTPResponse) {
-        self.response=response
-    }
-    
-    func writeTrailer(key: String, value: String) {
-        fatalError("Not implemented")
-    }
-    
-    func writeBody(data: DispatchData, completion: @escaping (Result<POSIXError, ()>) -> Void) {
-        self.responseBody = Data(data)
-        completion(Result(completion: ()))
-    }
-    func writeBody(data: DispatchData) /* convenience */ {
-        writeBody(data: data) { _ in
-            
+    func writeBody(_ data: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void) {
+        if let data = data as? HTTPResponseBody {
+            self.responseBody = data
+        } else {
+            self.responseBody = data.withUnsafeBytes { Data($0) }
         }
+        completion(.ok)
     }
     
-    func writeBody(data: Data, completion: @escaping (Result<POSIXError, ()>) -> Void) {
-        self.responseBody = data
-        completion(Result(completion: ()))
-    }
-    
-    func writeBody(data: Data) /* convenience */ {
-        writeBody(data: data) { _ in
-            
-        }
-    }
-    
-    func done(completion: @escaping (Result<POSIXError, ()>) -> Void) {
-        completion(Result(completion: ()))
+    func done(completion: @escaping (Result) -> Void) {
+        completion(.ok)
     }
     func done() /* convenience */ {
         done() { _ in

--- a/Tests/BlueSocketHTTPTests/ServerTests.swift
+++ b/Tests/BlueSocketHTTPTests/ServerTests.swift
@@ -29,7 +29,7 @@ class ServerTests: XCTestCase {
         XCTAssertNotNil(resolver.response)
         XCTAssertNotNil(resolver.responseBody)
         XCTAssertEqual(HTTPResponseStatus.ok.code, resolver.response?.status.code ?? 0)
-        XCTAssertEqual(testString, String(data: resolver.responseBody ?? Data(), encoding: .utf8) ?? "Nil")
+        XCTAssertEqual(testString, resolver.responseBody?.withUnsafeBytes { String(bytes: $0, encoding: .utf8) } ?? "Nil")
     }
     
     func testHello() {
@@ -39,25 +39,25 @@ class ServerTests: XCTestCase {
         XCTAssertNotNil(resolver.response)
         XCTAssertNotNil(resolver.responseBody)
         XCTAssertEqual(HTTPResponseStatus.ok.code, resolver.response?.status.code ?? 0)
-        XCTAssertEqual("Hello, World!", String(data: resolver.responseBody ?? Data(), encoding: .utf8) ?? "Nil")
+        XCTAssertEqual("Hello, World!", resolver.responseBody?.withUnsafeBytes { String(bytes: $0, encoding: .utf8) } ?? "Nil")
     }
     
     func testSimpleHello() {
         let request = HTTPRequest(method: .get, target:"/helloworld", httpVersion: HTTPVersion(major: 1, minor: 1), headers: ["X-foo": "bar"])
         let resolver = TestResponseResolver(request: request, requestBody: Data())
-        let simpleHelloWebApp = SimpleResponseCreator { (request, body) -> (reponse: HTTPResponse, responseBody: Data) in
-            return (HTTPResponse(httpVersion: request.httpVersion,
-                                 status: .ok,
-                                 transferEncoding: .chunked,
-                                 headers: ["X-foo": "bar"]),
-                    "Hello, World!".data(using: .utf8)!)
+        let simpleHelloWebApp = SimpleResponseCreator { (request, body) -> SimpleResponseCreator.Response in
+            return SimpleResponseCreator.Response(
+                status: .ok,
+                headers: ["X-foo": "bar"],
+                body: "Hello, World!".data(using: .utf8)!
+            )
             
         }
         resolver.resolveHandler(simpleHelloWebApp.serve)
         XCTAssertNotNil(resolver.response)
         XCTAssertNotNil(resolver.responseBody)
         XCTAssertEqual(HTTPResponseStatus.ok.code, resolver.response?.status.code ?? 0)
-        XCTAssertEqual("Hello, World!", String(data: resolver.responseBody ?? Data(), encoding: .utf8) ?? "Nil")
+        XCTAssertEqual("Hello, World!", resolver.responseBody?.withUnsafeBytes { String(bytes: $0, encoding: .utf8) } ?? "Nil")
     }
     
     func testOkEndToEnd() {
@@ -121,12 +121,12 @@ class ServerTests: XCTestCase {
     
     func testSimpleHelloEndToEnd() {
         let receivedExpectation = self.expectation(description: "Received web response \(#function)")
-        let simpleHelloWebApp = SimpleResponseCreator { (request, body) -> (reponse: HTTPResponse, responseBody: Data) in
-            return (HTTPResponse(httpVersion: request.httpVersion,
-                                 status: .ok,
-                                 transferEncoding: .chunked,
-                                 headers: ["X-foo": "bar"]),
-                    "Hello, World!".data(using: .utf8)!)
+        let simpleHelloWebApp = SimpleResponseCreator { (request, body) -> SimpleResponseCreator.Response in
+            return SimpleResponseCreator.Response(
+                status: .ok,
+                headers: ["X-foo": "bar"],
+                body: "Hello, World!".data(using: .utf8)!
+            )
             
         }
 


### PR DESCRIPTION
* `HTTPResponse` is redundent. Its `status` and `headers` properties
  are moved to parameters of `writeHeader` method of `HTTPResponseWriter`
  instance. `transferEncoding` handling is moved to `HTTPHeaders` - it
  is not as simple as an enum and depends on used HTTP protocol version
  and capabilites set by a client in its request headers.
  `httpVersion` should not be configured by an outer scope - a server should
  use the HTTP version which was requested by a client.

* `writeResponse` and `writeContinue` are replaced by `writeHeader`.

* `writeTrailer` accepts trailers as `HTTPHeaders` struct.

* All `write*` methods accept a completion handler.

* `writeBody` accepts `UnsafeHTTPResponseBody` instead of just `Data`
  and `Dispatch`. It should be used only in the scope of a call and a
  copy should be made or value should be checked for `HTTPResponseBody`
  conformance before storing it anythere. This approch allows to reduce
  memory copying.

* `Result<POSIXError, Void>` enum is replaced with `Result`. In the
  first case `POSIXError` and `Void` are generic parameters names, not
  types. I think this behaviour was unintended.

Some problems with sync/async API still exist (and in the reference implementation of `HTTPStreamingParser` too). They should be addressed in an ongoing PR, after an agreement on the proposed changes.