### PR TITLE
Perf: read connectionCount only when needed

### DIFF
--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -374,14 +374,16 @@ public class StreamingParser: HTTPResponseWriter {
             headers[.transferEncoding] = nil
         }
 
-        let availableConnections = maxRequests - (self.connectionCounter?.connectionCount ?? 0)
 
-        if clientRequestedKeepAlive && (availableConnections > 0) {
-            headers[.connection] = "Keep-Alive"
-            headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(availableConnections)"
-        } else {
-            headers[.connection] = "Close"
+        if clientRequestedKeepAlive {
+            let availableConnections = maxRequests - (self.connectionCounter?.connectionCount ?? 0)
+            if availableConnections > 0 {
+                headers[.connection] = "Keep-Alive"
+                headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(availableConnections)"
+                return
+            }
         }
+        headers[.connection] = "Close"
     }
     
     public func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void) {


### PR DESCRIPTION
`connectionCount` is only needed if keep alive is requested, so accessing the value should be done inside the `clientRequestedKeepAlive` check