### PR TITLE
Correct function of Keep-Alive header

### DIFF
--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -19,7 +19,7 @@ public class StreamingParser: HTTPResponseWriter {
     /// Time to leave socket open waiting for next request to start
     public static let keepAliveTimeout: TimeInterval = 5
 
-    /// Flag to track if the client wants to send multiple requests on the same TCP connection
+    /// Flag to track if the client wants to send consecutive requests on the same TCP connection
     var clientRequestedKeepAlive = false
 
     /// Tracks when socket should be closed. Needs to have a lock, since it's updated often
@@ -42,12 +42,10 @@ public class StreamingParser: HTTPResponseWriter {
         }
     }
 
-    /// Theoretical limit of how many open requests we can have. Used in Keep-Alive Header
-    let maxRequests = 100
+    /// Limit on the number of consecutive requests on a single keepalive connection. Used in Keep-Alive Header
+    public private(set) var maxRequests = 100
 
-    /// Optional delegate that can tell us how many connections are in-flight so we can set the Keep-Alive header
-    ///  to the correct number of available connections. If not present, the client will not be limited in number of 
-    ///  connections that can be made simultaneously
+    /// Optional delegate that can tell us how many connections are in-flight.
     public weak var connectionCounter: CurrentConnectionCounting?
 
     /// Holds the bytes that come from the CHTTPParser until we have enough of them to do something with it
@@ -392,10 +390,10 @@ public class StreamingParser: HTTPResponseWriter {
 
 
         if clientRequestedKeepAlive {
-            let availableConnections = maxRequests - (self.connectionCounter?.connectionCount ?? 0)
-            if availableConnections > 0 {
+            maxRequests -= 1
+            if maxRequests > 0 {
                 headers[.connection] = "Keep-Alive"
-                headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(availableConnections)"
+                headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(maxRequests)"
                 return
             }
         }

--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -42,9 +42,6 @@ public class StreamingParser: HTTPResponseWriter {
         }
     }
 
-    /// Limit on the number of consecutive requests on a single connection. Used in Keep-Alive Header
-    private(set) var requestsRemaining: UInt = 100
-
     /// Optional delegate that can tell us how many connections are in-flight.
     public weak var connectionCounter: CurrentConnectionCounting?
 
@@ -390,14 +387,10 @@ public class StreamingParser: HTTPResponseWriter {
 
 
         if clientRequestedKeepAlive {
-            requestsRemaining -= 1
-            if requestsRemaining > 0 {
-                headers[.connection] = "Keep-Alive"
-                headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(requestsRemaining)"
-                return
-            }
+            headers[.connection] = "Keep-Alive"
+        } else {
+            headers[.connection] = "Close"
         }
-        headers[.connection] = "Close"
     }
 
     public func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void) {

--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -42,8 +42,8 @@ public class StreamingParser: HTTPResponseWriter {
         }
     }
 
-    /// Limit on the number of consecutive requests on a single keepalive connection. Used in Keep-Alive Header
-    public private(set) var maxRequests = 100
+    /// Limit on the number of consecutive requests on a single connection. Used in Keep-Alive Header
+    private(set) var requestsRemaining: UInt = 100
 
     /// Optional delegate that can tell us how many connections are in-flight.
     public weak var connectionCounter: CurrentConnectionCounting?
@@ -390,10 +390,10 @@ public class StreamingParser: HTTPResponseWriter {
 
 
         if clientRequestedKeepAlive {
-            maxRequests -= 1
-            if maxRequests > 0 {
+            requestsRemaining -= 1
+            if requestsRemaining > 0 {
                 headers[.connection] = "Keep-Alive"
-                headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(maxRequests)"
+                headers[.keepAlive] = "timeout=\(Int(StreamingParser.keepAliveTimeout)), max=\(requestsRemaining)"
                 return
             }
         }

--- a/Tests/HTTPTests/ServerTests.swift
+++ b/Tests/HTTPTests/ServerTests.swift
@@ -220,10 +220,8 @@ class ServerTests: XCTestCase {
                 XCTAssertNotNil(response)
                 let headers = response?.allHeaderFields ?? ["": ""]
                 let connectionHeader: String = headers["Connection"] as? String ?? ""
-                let keepAliveHeader = headers["Keep-Alive"]
                 XCTAssertEqual(connectionHeader, "Keep-Alive", "No Keep-Alive Connection")
-                XCTAssertNotNil(keepAliveHeader)
-                XCTAssertNotNil(responseBody, "No Keep-Alive Header")
+                XCTAssertNotNil(responseBody, "No Response Body")
                 XCTAssertEqual(server.connectionCount, 1)
                 XCTAssertEqual(Int(HTTPResponseStatus.ok.code), response?.statusCode ?? 0)
                 XCTAssertEqual(testString1, String(data: responseBody ?? Data(), encoding: .utf8) ?? "Nil")
@@ -237,9 +235,7 @@ class ServerTests: XCTestCase {
                     XCTAssertNotNil(response2)
                     let headers = response2?.allHeaderFields ?? ["": ""]
                     let connectionHeader: String = headers["Connection"] as? String ?? ""
-                    let keepAliveHeader = headers["Keep-Alive"]
                     XCTAssertEqual(connectionHeader, "Keep-Alive", "No Keep-Alive Connection")
-                    XCTAssertNotNil(keepAliveHeader, "No Keep-Alive Header")
                     XCTAssertEqual(server.connectionCount, 1)
                     XCTAssertNotNil(responseBody2)
                     XCTAssertEqual(Int(HTTPResponseStatus.ok.code), response2?.statusCode ?? 0)
@@ -254,9 +250,7 @@ class ServerTests: XCTestCase {
                         XCTAssertNotNil(response)
                         let headers = response?.allHeaderFields ?? ["": ""]
                         let connectionHeader: String = headers["Connection"] as? String ?? ""
-                        let keepAliveHeader = headers["Keep-Alive"]
                         XCTAssertEqual(connectionHeader, "Keep-Alive", "No Keep-Alive Connection")
-                        XCTAssertNotNil(keepAliveHeader, "No Keep-Alive Header")
                         XCTAssertEqual(server.connectionCount, 1)
                         XCTAssertNotNil(responseBody)
                         XCTAssertEqual(Int(HTTPResponseStatus.ok.code), response?.statusCode ?? 0)


### PR DESCRIPTION
The HTTP `Keep-Alive` response header \[[1](https://tools.ietf.org/id/draft-thomson-hybi-http-timeout-03.html#rfc.section.2)\] `max` parameter indicates the number of remaining requests that a client may make before the server closes the connection.

The current implementation seems to be trying to take into account the number of active connections to the server when responding, which does not seem correct. This PR changes the value sent to be a simple count of requests remaining.  Once the count becomes zero, a `Connection: Close` header is sent.

\[1\]: https://tools.ietf.org/id/draft-thomson-hybi-http-timeout-03.html#rfc.section.2