### PR TITLE
Fix port configuration being ignored

### DIFF
--- a/Sources/HTTP/HTTPServer.swift
+++ b/Sources/HTTP/HTTPServer.swift
@@ -32,7 +32,7 @@ public class HTTPServer: HTTPServing {
     }
 
     public func start(port: Int = 0, handler: @escaping HTTPRequestHandler) throws {
-        try server.start(handler: handler)
+        try server.start(port: port, handler: handler)
     }
 
     public func stop() {

--- a/Sources/HTTP/PoCSocket/PoCSocket.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocket.swift
@@ -200,14 +200,14 @@ internal class PoCSocket {
         #if os(Linux)
             var addr = sockaddr_in(
                 sin_family: sa_family_t(AF_INET),
-                sin_port: UInt16(port),
+                sin_port: htons(UInt16(port)),
                 sin_addr: in_addr(s_addr: in_addr_t(0)),
                 sin_zero:(0, 0, 0, 0, 0, 0, 0, 0))
         #else
             var addr = sockaddr_in(
                 sin_len: UInt8(MemoryLayout<sockaddr_in>.stride),
                 sin_family: UInt8(AF_INET),
-                sin_port: UInt16(port),
+                sin_port: (Int(OSHostByteOrder()) != OSLittleEndian ? UInt16(port) : _OSSwapInt16(UInt16(port))),
                 sin_addr: in_addr(s_addr: in_addr_t(0)),
                 sin_zero:(0, 0, 0, 0, 0, 0, 0, 0))
         #endif


### PR DESCRIPTION
Setting the port for the HTTPServer() was being ignore, both because we weren't passing the port down to the underlying server and socket, and because PoCSocket wasn't carrying out the host to network byte order conversion on Darwin.