### PR TITLE
Convert writeXXXX() calls to write(xxxx:)

### DIFF
--- a/Sources/HTTP/HTTPResponse.swift
+++ b/Sources/HTTP/HTTPResponse.swift
@@ -22,21 +22,21 @@ public struct HTTPResponse {
 /// HTTPResponseWriter provides functions to create an HTTP response
 public protocol HTTPResponseWriter : class {
     /// Writer function to create the headers for an HTTP response
-    /// - Parameter status: The status code to include in the HTTP response
     /// - Parameter headers: The HTTP headers to include in the HTTP response
+    /// - Parameter status: The status code to include in the HTTP response
     /// - Parameter completion: Closure that is called when the HTTP headers have been written to the HTTP respose
-    func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders, completion: @escaping (Result) -> Void)
+    func write(headers: HTTPHeaders, status: HTTPResponseStatus, completion: @escaping (Result) -> Void)
 
     /// Writer function to write a trailer header as part of the HTTP response
     /// - Parameter trailers: The trailers to write as part of the HTTP response
     /// - Parameter completion: Closure that is called when the trailers has been written to the HTTP response
     /// This is not currently implemented
-    func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void)
+    func write(trailers: HTTPHeaders, completion: @escaping (Result) -> Void)
 
     /// Writer function to write data to the body of the HTTP response
-    /// - Parameter data: The data to write as part of the HTTP response
+    /// - Parameter body: The body data to write as part of the HTTP response
     /// - Parameter completion: Closure that is called when the data has been written to the HTTP response
-    func writeBody(_ data: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void)
+    func write(body: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void)
 
     /// Writer function to complete the HTTP response
     /// - Parameter completion: Closure that is called when the HTTP response has been completed
@@ -49,27 +49,27 @@ public protocol HTTPResponseWriter : class {
 /// Convenience methods for HTTP response writer.
 extension HTTPResponseWriter {
     /// Convenience function to write the headers for an HTTP response without a completion handler
-    /// - See: `writeHeader(status:headers:completion:)`
-    public func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders) {
-        writeHeader(status: status, headers: headers) { _ in }
+    /// - See: `write(headres:status:completion:)`
+    public func write(headers: HTTPHeaders, status: HTTPResponseStatus) {
+        write(headers: headers, status: status) { _ in }
     }
 
     /// Convenience function to write a HTTP response with no headers or completion handler
-    /// - See: `writeHeader(status:headers:completion:)`
-    public func writeHeader(status: HTTPResponseStatus) {
-        writeHeader(status: status, headers: [:])
+    /// - See: `write(headers:status:completion:)`
+    public func write(status: HTTPResponseStatus) {
+        write(headers: [:], status: status)
     }
 
     /// Convenience function to write a trailer header as part of the HTTP response without a completion handler
-    /// - See: `writeTrailer(_:completion:)`
-    public func writeTrailer(_ trailers: HTTPHeaders) {
-        writeTrailer(trailers) { _ in }
+    /// - See: `write(trailers:completion:)`
+    public func write(trailers: HTTPHeaders) {
+        write(trailers: trailers) { _ in }
     }
 
-    /// Convenience function for writing `data` to the body of the HTTP response without a completion handler.
-    /// - See: writeBody(_:completion:)
-    public func writeBody(_ data: UnsafeHTTPResponseBody) {
-        return writeBody(data) { _ in }
+    /// Convenience function for writing body data to the HTTP response without a completion handler.
+    /// - See: write(body:completion:)
+    public func write(body: UnsafeHTTPResponseBody) {
+        return write(body: body) { _ in }
     }
 
     /// Convenience function to complete the HTTP response without a completion handler.

--- a/Tests/HTTPTests/Helpers/EchoHandler.swift
+++ b/Tests/HTTPTests/Helpers/EchoHandler.swift
@@ -13,11 +13,11 @@ import HTTP
 class EchoHandler: HTTPRequestHandling {
     func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        response.writeHeader(status: .ok, headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"])
+        response.write(headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"], status: .ok)
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(let data, let finishedProcessing):
-                response.writeBody(data) { _ in
+                response.write(body: data) { _ in
                     finishedProcessing()
                 }
             case .end:

--- a/Tests/HTTPTests/Helpers/HelloWorldHandler.swift
+++ b/Tests/HTTPTests/Helpers/HelloWorldHandler.swift
@@ -13,13 +13,13 @@ import HTTP
 class HelloWorldHandler: HTTPRequestHandling {
     func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        response.writeHeader(status: .ok, headers: [.transferEncoding: "chunked", "X-foo": "bar"])
+        response.write(headers: [.transferEncoding: "chunked", "X-foo": "bar"], status: .ok)
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(_, let finishedProcessing):
                 finishedProcessing()
             case .end:
-                response.writeBody("Hello, World!")
+                response.write(body: "Hello, World!")
                 response.done()
             default:
                 stop = true /* don't call us anymore */

--- a/Tests/HTTPTests/Helpers/HelloWorldKeepAliveHandler.swift
+++ b/Tests/HTTPTests/Helpers/HelloWorldKeepAliveHandler.swift
@@ -13,17 +13,18 @@ import HTTP
 class HelloWorldKeepAliveHandler: HTTPRequestHandling {
     func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        response.writeHeader(status: .ok, headers: [
-            "Transfer-Encoding": "chunked",
-            "Connection": "Keep-Alive",
-            "Keep-Alive": "timeout=5, max=10",
-        ])
+        response.write(headers: [
+                        "Transfer-Encoding": "chunked",
+                        "Connection": "Keep-Alive",
+                        "Keep-Alive": "timeout=5, max=10",
+                        ],
+                       status: .ok)
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(_, let finishedProcessing):
                 finishedProcessing()
             case .end:
-                response.writeBody("Hello, World!")
+                response.write(body: "Hello, World!")
                 response.done()
             default:
                 stop = true /* don't call us anymore */

--- a/Tests/HTTPTests/Helpers/OkHandler.swift
+++ b/Tests/HTTPTests/Helpers/OkHandler.swift
@@ -13,7 +13,7 @@ import HTTP
 class OkHandler: HTTPRequestHandling {
     func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
-        response.writeHeader(status: .ok, headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"])
+        response.write(headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"], status: .ok)
         return .discardBody
     }
 }

--- a/Tests/HTTPTests/Helpers/SimpleResponseCreator.swift
+++ b/Tests/HTTPTests/Helpers/SimpleResponseCreator.swift
@@ -44,8 +44,8 @@ public class SimpleResponseCreator: HTTPRequestHandling {
                 let responseResult = self.completionHandler(request, self.buffer)
                 var headers = responseResult.headers
                 headers.replace([.transferEncoding: "chunked"])
-                response.writeHeader(status: responseResult.status, headers: headers)
-                response.writeBody(responseResult.body) { _ in
+                response.write(headers: headers, status: responseResult.status)
+                response.write(body: responseResult.body) { _ in
                         response.done()
                 }
             default:

--- a/Tests/HTTPTests/Helpers/TestResponseResolver.swift
+++ b/Tests/HTTPTests/Helpers/TestResponseResolver.swift
@@ -42,20 +42,20 @@ class TestResponseResolver: HTTPResponseWriter {
         }
     }
 
-    func writeHeader(status: HTTPResponseStatus, headers: HTTPHeaders, completion: @escaping (Result) -> Void) {
+    func write(headers: HTTPHeaders, status: HTTPResponseStatus, completion: @escaping (Result) -> Void) {
         self.response = (status: status, headers: headers)
         completion(.ok)
     }
 
-    func writeTrailer(_ trailers: HTTPHeaders, completion: @escaping (Result) -> Void) {
+    func write(trailers: HTTPHeaders, completion: @escaping (Result) -> Void) {
         fatalError("Not implemented")
     }
 
-    func writeBody(_ data: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void) {
-        if let data = data as? HTTPResponseBody {
+    func write(body: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void) {
+        if let data = body as? HTTPResponseBody {
             self.responseBody = data
         } else {
-            self.responseBody = data.withUnsafeBytes { Data($0) }
+            self.responseBody = body.withUnsafeBytes { Data($0) }
         }
         completion(.ok)
     }


### PR DESCRIPTION
As proposed by Georgios Moschovitis on the mailing list, this converts the `HTTPResponseWriter.writeXXXX()` functions to `HTTPResponseWriter.write(xxxx:)`.

This gives an API surface of:
```swift
// Headers
write(headers: HTTPHeaders, status: HTTPResponseStatus, completion: @escaping (Result) -> Void)
write(headers: HTTPHeaders, status: HTTPResponseStatus)
write(status: HTTPResponseStatus)

// Body
write(body: UnsafeHTTPResponseBody, completion: @escaping (Result) -> Void)
write(body: UnsafeHTTPResponseBody) 

// Trailers
write(trailers: HTTPHeaders, completion: @escaping (Result) -> Void)
write(trailers: HTTPHeaders)
```

The area worth discussing is the following function:
```
write(status: HTTPResponseStatus)
```
This is a convenience wrapper for writing headers, so a side effect is that it may not be obvious that it results in the writing of the headers to the socket - i.e. a subsequent call to `write(headers:)` isn't possible.