### PR TITLE
Attempt to stop a crash running `self?.responseCompleted = false`

### DIFF
--- a/Sources/HTTP/PoCSocket/PoCSocketConnectionListener.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocketConnectionListener.swift
@@ -226,7 +226,7 @@ public class PoCSocketConnectionListener: ParserConnecting {
                     var readBuffer: UnsafeMutablePointer<Int8> = UnsafeMutablePointer<Int8>.allocate(capacity: maxLength)
                     length = try strongSelf.socket?.socketRead(into: &readBuffer, maxLength:maxLength) ?? -1
                     if length > 0 {
-                        self?.responseCompleted = false
+                        strongSelf.responseCompleted = false
                         
                         let data = Data(bytes: readBuffer, count: length)
                         let numberParsed = strongSelf.parser?.readStream(data:data) ?? 0
@@ -241,22 +241,24 @@ public class PoCSocketConnectionListener: ParserConnecting {
                 }
             } catch {
                 print("ReaderSource Event Error: \(error)")
-                self?.readerSource?.cancel()
-                self?.errorOccurred = true
-                self?.close()
+                strongSelf.readerSource?.cancel()
+                strongSelf.errorOccurred = true
+                strongSelf.close()
             }
             if length == 0 {
-                self?.readerSource?.cancel()
+                strongSelf.readerSource?.cancel()
             }
             if length < 0 {
-                self?.errorOccurred = true
-                self?.readerSource?.cancel()
-                self?.close()
+                strongSelf.errorOccurred = true
+                strongSelf.readerSource?.cancel()
+                strongSelf.close()
             }
         }
         
         tempReaderSource.setCancelHandler { [weak self] in
-            self?.close() //close if we can
+            if let strongSelf = self {
+                strongSelf.close() //close if we can
+            }
         }
         
         self.readerSource = tempReaderSource


### PR DESCRIPTION
```
 * thread #1, name = 'SwiftServerHttp', stop reason = signal SIGILL
 * frame #0: 0x00007f50a53f5d93 libdispatch.so`_os_object_release + 35
    frame #1: 0x00007f50a54115fd libdispatch.so`Dispatch.__DispatchData.__deallocating_deinit + 13
    frame #2: 0x00007f50a5419189 libdispatch.so`Dispatch.DispatchSource.__deallocating_deinit + 9
    frame #3: 0x00007f50a511464b libswiftCore.so`_swift_release_dealloc + 11
    frame #4: 0x00007fff5ec2b991 SwiftServerHttpTestBed`__swift_destroy_boxed_opaque_existential_1 at HTTPResponse.swift:0
    frame #5: 0x00007fff5ec4a59b SwiftServerHttpTestBed`closure #1 in PoCSocketConnectionListener.process(self=<unavailable>) at PoCSocketConnectionListener.swift:229
```