### PR TITLE
Use 'guard a == b else' instead of 'if a != b'

### DIFF
--- a/Sources/HTTP/HTTPVersion.swift
+++ b/Sources/HTTP/HTTPVersion.swift
@@ -40,11 +40,10 @@ extension HTTPVersion : Hashable {
 extension HTTPVersion : Comparable {
     /// :nodoc:
     public static func < (lhs: HTTPVersion, rhs: HTTPVersion) -> Bool {
-        if lhs.major != rhs.major {
+        guard lhs.major == rhs.major else {
             return lhs.major < rhs.major
-        } else {
-            return lhs.minor < rhs.minor
         }
+        return lhs.minor < rhs.minor
     }
 
 }


### PR DESCRIPTION
Improve readability of `HTTPVersion` `Comparable` implementation.