### PR TITLE
Rename start/stop to resume/suspend

### DIFF
--- a/Sources/HTTP/HTTPServer.swift
+++ b/Sources/HTTP/HTTPServer.swift
@@ -10,10 +10,10 @@
 public protocol HTTPServing : class {
 
     /// Start the HTTP server on the given `port`, using `handler` to process incoming requests
-    func start(port: Int, handler: @escaping HTTPRequestHandler) throws
+    func resume(port: Int, handler: @escaping HTTPRequestHandler) throws
 
     /// Stop the server
-    func stop()
+    func suspend()
 
     /// The port the server is listening on
     var port: Int { get }
@@ -33,13 +33,13 @@ public class HTTPServer: HTTPServing {
     }
 
     /// Start the HTTP server on the given `port` number, using a `HTTPRequestHandler` to process incoming requests.
-    public func start(port: Int = 0, handler: @escaping HTTPRequestHandler) throws {
-        try server.start(port: port, handler: handler)
+    public func resume(port: Int = 0, handler: @escaping HTTPRequestHandler) throws {
+        try server.resume(port: port, handler: handler)
     }
 
     /// Stop the server
-    public func stop() {
-        server.stop()
+    public func suspend() {
+        server.suspend()
     }
 
     /// The port number the server is listening on

--- a/Sources/HTTP/PoCSocket/PoCSocketSimpleServer.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocketSimpleServer.swift
@@ -55,13 +55,13 @@ public class PoCSocketSimpleServer: CurrentConnectionCounting {
         }
     }
 
-    /// Starts the server listening on a given port
+    /// Starts/resumes the server listening on a given port
     ///
     /// - Parameters:
     ///   - port: TCP port. See listen(2)
     ///   - handler: Function that creates the HTTP Response from the HTTP Request
     /// - Throws: Error (usually a socket error) generated
-    public func start(port: Int = 0,
+    public func resume(port: Int = 0,
                       queueCount: Int = 0,
                       acceptCount: Int = 0,
                       maxReadLength: Int = 1048576,
@@ -133,8 +133,8 @@ public class PoCSocketSimpleServer: CurrentConnectionCounting {
         }
     }
 
-    /// Stop the server and close the sockets
-    public func stop() {
+    /// Stop/suspend the server and close the sockets
+    public func suspend() {
         isShuttingDown = true
         connectionListenerList.closeAll()
         serverSocket.shutdownAndClose()

--- a/Tests/HTTPTests/ServerTests.swift
+++ b/Tests/HTTPTests/ServerTests.swift
@@ -64,7 +64,7 @@ class ServerTests: XCTestCase {
 
         let server = HTTPServer()
         do {
-            try server.start(port: 0, handler: OkHandler().handle)
+            try server.resume(port: 0, handler: OkHandler().handle)
             let session = URLSession(configuration: .default)
             let url = URL(string: "http://localhost:\(server.port)/")!
             print("Test \(#function) on port \(server.port)")
@@ -82,7 +82,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            server.stop()
+            server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -93,7 +93,7 @@ class ServerTests: XCTestCase {
 
         let server = HTTPServer()
         do {
-            try server.start(port: 0, handler: HelloWorldHandler().handle)
+            try server.resume(port: 0, handler: HelloWorldHandler().handle)
             let session = URLSession(configuration: .default)
             let url = URL(string: "http://localhost:\(server.port)/helloworld")!
             print("Test \(#function) on port \(server.port)")
@@ -112,7 +112,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            server.stop()
+            server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -130,7 +130,7 @@ class ServerTests: XCTestCase {
 
         let server = HTTPServer()
         do {
-            try server.start(port: 0, handler: simpleHelloWebApp.handle)
+            try server.resume(port: 0, handler: simpleHelloWebApp.handle)
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -156,7 +156,7 @@ class ServerTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        server.stop()
+        server.suspend()
         print("\(#function) stopping server")
     }
 
@@ -166,7 +166,7 @@ class ServerTests: XCTestCase {
 
         let server = HTTPServer()
         do {
-            try server.start(port: 0, handler: EchoHandler().handle)
+            try server.resume(port: 0, handler: EchoHandler().handle)
             let session = URLSession(configuration: .default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -190,7 +190,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            server.stop()
+            server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -206,7 +206,7 @@ class ServerTests: XCTestCase {
 
         let server = HTTPServer()
         do {
-            try server.start(port: 0, handler: EchoHandler().handle)
+            try server.resume(port: 0, handler: EchoHandler().handle)
             let session = URLSession(configuration: .default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -271,7 +271,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            //server.stop()
+            //server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -287,7 +287,7 @@ class ServerTests: XCTestCase {
         
         let server = HTTPServer()
         do {
-            try server.start(port: 0, handler: EchoHandler().handle)
+            try server.resume(port: 0, handler: EchoHandler().handle)
             let session = URLSession(configuration: .default)
             let url1 = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -362,7 +362,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            //server.stop()
+            //server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -398,7 +398,7 @@ class ServerTests: XCTestCase {
 
         let server = PoCSocketSimpleServer()
         do {
-            try server.start(port: 0, maxReadLength: chunkSize, handler: EchoHandler().handle)
+            try server.resume(port: 0, maxReadLength: chunkSize, handler: EchoHandler().handle)
             let session = URLSession(configuration: .default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -420,7 +420,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            server.stop()
+            server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -451,7 +451,7 @@ class ServerTests: XCTestCase {
         let server = PoCSocketSimpleServer()
         do {
             let testHandler = AbortAndSendHelloHandler()
-            try server.start(port: 0, maxReadLength: chunkSize, handler: testHandler.handle)
+            try server.resume(port: 0, maxReadLength: chunkSize, handler: testHandler.handle)
             let session = URLSession(configuration: .default)
             let url = URL(string: "http://localhost:\(server.port)/echo")!
             print("Test \(#function) on port \(server.port)")
@@ -475,7 +475,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            server.stop()
+            server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }
@@ -488,7 +488,7 @@ class ServerTests: XCTestCase {
         let keepAliveTimeout = 0.1
 
         do {
-            try server.start(port: 0, keepAliveTimeout: keepAliveTimeout, handler: OkHandler().handle)
+            try server.resume(port: 0, keepAliveTimeout: keepAliveTimeout, handler: OkHandler().handle)
             
             let session = URLSession(configuration: .default)
             let url1 = URL(string: "http://localhost:\(server.port)")!
@@ -517,7 +517,7 @@ class ServerTests: XCTestCase {
                     XCTFail("\(error)")
                 }
             }
-            server.stop()
+            server.suspend()
         } catch {
             XCTFail("Error listening on port \(0): \(error). Use server.failed(callback:) to handle")
         }


### PR DESCRIPTION
Rename start/stop to resume/suspend to match what GCD and Cocoa are doing.
Affects:
HTTPServing protocol
HTTPServer class
PoCSocketSimpleServer