### PR TITLE
Add optional `queue` to handler

### DIFF
--- a/Sources/HTTP/HTTPCommon.swift
+++ b/Sources/HTTP/HTTPCommon.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 
 /// Typealias for a closure that handles an incoming HTTP request
 /// The following is an example of an echo `HTTPRequestHandler` that returns the request it receives as a response:

--- a/Sources/HTTP/HTTPCommon.swift
+++ b/Sources/HTTP/HTTPCommon.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Typealias for a closure that handles an incoming HTTP request
 /// The following is an example of an echo `HTTPRequestHandler` that returns the request it receives as a response:
 /// ```swift
-///    func echo(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+///    func echo(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
 ///        response.writeHeader(status: .ok)
 ///        return .processBody { (chunk, stop) in
 ///            switch chunk {
@@ -29,20 +29,26 @@ import Foundation
 ///    }
 /// ```
 /// This then needs to be registered with the server using `HTTPServer.start(port:handler:)`
-/// - Parameter req: the incoming HTTP request.
-/// - Parameter res: a writer providing functions to create an HTTP reponse to the request.
-/// - Returns HTTPBodyProcessing: a enum that either discards the request data, or provides a closure to process it.
-public typealias HTTPRequestHandler = (HTTPRequest, HTTPResponseWriter) -> HTTPBodyProcessing
+/// - Parameters:
+///   - req: the incoming HTTP request.
+///   - res: a writer providing functions to create an HTTP reponse to the request.
+///   - queue: optional, if set, dispatch done callbacks back to this queue (if
+///            the handler processing escapes the calling queue)
+/// - Returns: HTTPBodyProcessing: a enum that either discards the request data, or provides a closure to process it.
+public typealias HTTPRequestHandler = (HTTPRequest, HTTPResponseWriter, DispatchQueue?) -> HTTPBodyProcessing
 
 /// Class protocol containing a `handle()` function that implements `HTTPRequestHandler` to respond to incoming HTTP requests.
 /// - See: `HTTPRequestHandler` for more information
 public protocol HTTPRequestHandling: class {
     /// handle: function that implements `HTTPRequestHandler` and is called when a new HTTP request is received by the HTTP server.
-    /// - Parameter request: the incoming HTTP request.
-    /// - Parameter response: a writer providing functions to create an HTTP response to the request.
-    /// - Returns HTTPBodyProcessing: a enum that either discards the request data, or provides a closure to process it.
+    /// - Parameters:
+    ///   - request: the incoming HTTP request.
+    ///   - response: a writer providing functions to create an HTTP response to the request.
+    ///   - queue: optional, if set, dispatch done callbacks back to this queue (if
+    ///            the handler processing escapes the calling queue)
+    /// - Returns: HTTPBodyProcessing: a enum that either discards the request data, or provides a closure to process it.
     /// - See: `HTTPRequestHandler` for more information
-    func handle(request: HTTPRequest, response: HTTPResponseWriter) -> HTTPBodyProcessing
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue?) -> HTTPBodyProcessing
 }
 
 /// The result returned as part of a completion handler

--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -211,7 +211,7 @@ public class StreamingParser: HTTPResponseWriter {
             self.parserBuffer = nil
 
             if !upgradeRequested {
-                self.httpBodyProcessingCallback = self.handle(self.createRequest(), self)
+                self.httpBodyProcessingCallback = self.handle(self.createRequest(), self, nil)
             }
         case .urlReceived:
             if let parserBuffer = self.parserBuffer {

--- a/Tests/HTTPTests/Helpers/AbortAndSendHelloHandler.swift
+++ b/Tests/HTTPTests/Helpers/AbortAndSendHelloHandler.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 import HTTP
 
 /// Simple `HTTPRequestHandler` that prints "Hello, World" as per K&R

--- a/Tests/HTTPTests/Helpers/AbortAndSendHelloHandler.swift
+++ b/Tests/HTTPTests/Helpers/AbortAndSendHelloHandler.swift
@@ -15,7 +15,7 @@ class AbortAndSendHelloHandler: HTTPRequestHandling {
     var chunkCalledCount=0
     var chunkLength=0
     
-    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         response.writeHeader(status: .ok, headers: [.transferEncoding: "chunked", "X-foo": "bar"])
         return .processBody { (chunk, stop) in

--- a/Tests/HTTPTests/Helpers/EchoHandler.swift
+++ b/Tests/HTTPTests/Helpers/EchoHandler.swift
@@ -11,7 +11,7 @@ import HTTP
 
 /// Simple `HTTPRequestHandler` that just echoes back whatever input it gets
 class EchoHandler: HTTPRequestHandling {
-    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         response.writeHeader(status: .ok, headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"])
         return .processBody { (chunk, stop) in

--- a/Tests/HTTPTests/Helpers/EchoHandler.swift
+++ b/Tests/HTTPTests/Helpers/EchoHandler.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 import HTTP
 
 /// Simple `HTTPRequestHandler` that just echoes back whatever input it gets

--- a/Tests/HTTPTests/Helpers/HelloWorldHandler.swift
+++ b/Tests/HTTPTests/Helpers/HelloWorldHandler.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 import HTTP
 
 /// Simple `HTTPRequestHandler` that prints "Hello, World" as per K&R

--- a/Tests/HTTPTests/Helpers/HelloWorldHandler.swift
+++ b/Tests/HTTPTests/Helpers/HelloWorldHandler.swift
@@ -11,7 +11,7 @@ import HTTP
 
 /// Simple `HTTPRequestHandler` that prints "Hello, World" as per K&R
 class HelloWorldHandler: HTTPRequestHandling {
-    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         response.writeHeader(status: .ok, headers: [.transferEncoding: "chunked", "X-foo": "bar"])
         return .processBody { (chunk, stop) in

--- a/Tests/HTTPTests/Helpers/HelloWorldKeepAliveHandler.swift
+++ b/Tests/HTTPTests/Helpers/HelloWorldKeepAliveHandler.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 import HTTP
 
 /// `HelloWorldRequestHandler` that sets the keep alive header for XCTest purposes

--- a/Tests/HTTPTests/Helpers/HelloWorldKeepAliveHandler.swift
+++ b/Tests/HTTPTests/Helpers/HelloWorldKeepAliveHandler.swift
@@ -11,7 +11,7 @@ import HTTP
 
 /// `HelloWorldRequestHandler` that sets the keep alive header for XCTest purposes
 class HelloWorldKeepAliveHandler: HTTPRequestHandling {
-    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         response.writeHeader(status: .ok, headers: [
             "Transfer-Encoding": "chunked",

--- a/Tests/HTTPTests/Helpers/OkHandler.swift
+++ b/Tests/HTTPTests/Helpers/OkHandler.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 import HTTP
 
 /// Simple `HTTPRequestHandler` that returns 200: OK without a body

--- a/Tests/HTTPTests/Helpers/OkHandler.swift
+++ b/Tests/HTTPTests/Helpers/OkHandler.swift
@@ -11,7 +11,7 @@ import HTTP
 
 /// Simple `HTTPRequestHandler` that returns 200: OK without a body
 class OkHandler: HTTPRequestHandling {
-    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         response.writeHeader(status: .ok, headers: ["Transfer-Encoding": "chunked", "X-foo": "bar"])
         return .discardBody

--- a/Tests/HTTPTests/Helpers/SimpleResponseCreator.swift
+++ b/Tests/HTTPTests/Helpers/SimpleResponseCreator.swift
@@ -32,7 +32,7 @@ public class SimpleResponseCreator: HTTPRequestHandling {
 
     var buffer = Data()
 
-    public func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    public func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         return .processBody { (chunk, stop) in
             switch chunk {
             case .chunk(let data, let finishedProcessing):

--- a/Tests/HTTPTests/Helpers/SimpleResponseCreator.swift
+++ b/Tests/HTTPTests/Helpers/SimpleResponseCreator.swift
@@ -12,6 +12,7 @@
  */
 
 import Foundation
+import Dispatch
 import HTTP
 
 /// Simple block-based wrapper to create a `HTTPRequestHandler`. Normally used during XCTests

--- a/Tests/HTTPTests/Helpers/TestResponseResolver.swift
+++ b/Tests/HTTPTests/Helpers/TestResponseResolver.swift
@@ -50,7 +50,7 @@ class TestResponseResolver: HTTPResponseWriter {
     }
 
     func resolveHandler(_ handler: HTTPRequestHandler) {
-        let chunkHandler = handler(request, self)
+        let chunkHandler = handler(request, self, nil)
         if shouldStopProcessingBody {
             return
         }

--- a/Tests/HTTPTests/Helpers/UnchunkedHelloWorldHandler.swift
+++ b/Tests/HTTPTests/Helpers/UnchunkedHelloWorldHandler.swift
@@ -6,7 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 //
 
-import Foundation
+import Dispatch
 import HTTP
 
 /// Simple `HTTPRequestHandler` that prints "Hello, World" as per K&R

--- a/Tests/HTTPTests/Helpers/UnchunkedHelloWorldHandler.swift
+++ b/Tests/HTTPTests/Helpers/UnchunkedHelloWorldHandler.swift
@@ -11,7 +11,7 @@ import HTTP
 
 /// Simple `HTTPRequestHandler` that prints "Hello, World" as per K&R
 class UnchunkedHelloWorldHandler: HTTPRequestHandling {
-    func handle(request: HTTPRequest, response: HTTPResponseWriter ) -> HTTPBodyProcessing {
+    func handle(request: HTTPRequest, response: HTTPResponseWriter, queue: DispatchQueue? ) -> HTTPBodyProcessing {
         //Assume the router gave us the right request - at least for now
         let responseString = "Hello, World!"
         response.writeHeader(status: .ok, headers: [.contentLength: "\(responseString.lengthOfBytes(using: .utf8))"])


### PR DESCRIPTION
For async servers, there has to be a synchronization point
for done callbacks. This is what the `queue` is for.

If the handler doesn't dispatch to other queues but stays
within the calling one, it doesn't need to call the done
callbacks via

    queue.async { done() }

but can do a straight

    done()

But if the handler does perform its work async, it need
to use the given queue to call the done, e.g.:

    func workHard(req: HTTPRequest, res: HTTPResponseWriter, queue: DispatchQueue?) {
        DispatchQueue.background.async {
            // do hard work
            queue.async {
               res.writeHeader(status: .ok)
            }
        }
    }

etc.

We are using `DispatchQueue` here. Another option is to add a
non-optional

  HTTPSynchronizationContext protocol

(adapted by DispatchQueue or a uv or sync variant)