### PR TITLE
Any informational header (1XX) should be allowed to be written prior …

### DIFF
--- a/Sources/HTTP/HTTPStreamingParser.swift
+++ b/Sources/HTTP/HTTPStreamingParser.swift
@@ -366,10 +366,10 @@ public class StreamingParser: HTTPResponseWriter {
 
         var header = "HTTP/1.1 \(status.code) \(status.reasonPhrase)\r\n"
 
-        let isContinue = status == .continue
+        let isInformational = status.class == .informational
 
         var headers = headers
-        if !isContinue {
+        if !isInformational {
             adjustHeaders(status: status, headers: &headers)
         }
 
@@ -383,7 +383,7 @@ public class StreamingParser: HTTPResponseWriter {
         // TODO use requested encoding if specified
         if let data = header.data(using: .utf8) {
             self.parserConnector?.queueSocketWrite(data, completion: completion)
-            if !isContinue {
+            if !isInformational {
                 headersWritten = true
             }
         } else {


### PR DESCRIPTION
…to actual response headers.

Previously, this honor was only bestowed upon status 100 "Continue".