### PR TITLE
Add note in README.md about generating .xcodeproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,17 @@ Once any data chunk has been processed, `finishedProcessing()` should be called 
 
 When the response is complete, `response.done()` should be called.
 
-## Working on HTTP
-This project uses the [Swift Package Manager](https://swift.org/package-manager/).  To work on this project within Xcode you can run the Swift Package Manager command `swift package generate-xcodeproj` to generate an `.xcodeproj` to work on within Xcode.
-
 ## API Documentation
 Full Jazzy documentation of the API is available here:  
 <https://swift-server.github.io/http/>
 
-## Contributing Feedback
+## Contributing
+
+### Feedback
 We are actively seeking feedback on this prototype and your comments are extremely valuable. If you have any comments on the API design, the implementation, or any other aspects of this project, please email the [`swift-server-dev`](https://lists.swift.org/mailman/listinfo/swift-server-dev) mailing list.
+
+### Writing Code
+We also welcome code contributions.  If you are developing on macOS, you may want to work within Xcode.  This project uses the [Swift Package Manager](https://swift.org/package-manager/).  To work on this project within Xcode you can run the Swift Package Manager command `swift package generate-xcodeproj` to generate an `.xcodeproj` to work on within Xcode.
 
 ## Acknowledgements
 This project is based on an inital proposal from @weissi on the swift-server-dev mailing list:  

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Once any data chunk has been processed, `finishedProcessing()` should be called 
 
 When the response is complete, `response.done()` should be called.
 
+## Working on HTTP
+This project uses the [Swift Package Manager](https://swift.org/package-manager/).  To work on this project within Xcode you can run the Swift Package Manager command `swift package generate-xcodeproj` to generate an `.xcodeproj` to work on within Xcode.
+
 ## API Documentation
 Full Jazzy documentation of the API is available here:  
 <https://swift-server.github.io/http/>


### PR DESCRIPTION
Heard a comment on Swift Unwrapped that sometimes its confusing to newcomers to the Swift Package Manager to know that they can run a command to generate an `.xcodeproj` to work on a project within Xcode.  Maybe worth adding a note into the `README.md`?