### PR TITLE
Fixes error in Swift 4.2, and some deprecation warnings

### DIFF
--- a/Sources/HTTP/PoCSocket/PoCSocket.swift
+++ b/Sources/HTTP/PoCSocket/PoCSocket.swift
@@ -315,9 +315,9 @@ internal class PoCSocket: ConnectionDelegate  {
 
         isListening = true
 
-        var addr_in = sockaddr_in()
+        let addr_in = sockaddr_in()
 
-        listeningPort = try withUnsafePointer(to: &addr_in) { pointer in
+        listeningPort = try withUnsafePointer(to: addr_in) { pointer in
             var len = socklen_t(MemoryLayout<sockaddr_in>.size)
             if getsockname(socketfd, UnsafeMutablePointer(OpaquePointer(pointer)), &len) != 0 {
                 throw PoCSocketError.SocketOSError(errno: errno)


### PR DESCRIPTION
Fixes error:

Overlapping accesses to 'addr_in', but modification requires exclusive access; consider copying to a local variable